### PR TITLE
refactor: pluginsとrulesの記述を削除

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,7 +1,5 @@
 module.exports = {
-  plugins: ['stylelint-prettier'],
+  plugins: [],
   extends: ['stylelint-config-standard', 'stylelint-prettier/recommended'],
-  rules: {
-    'prettier/prettier': true,
-  },
+  rules: {},
 };


### PR DESCRIPTION
To integrate this plugin with `stylelint-config-prettier`, you can use the `"recommended"` configuration:

1.  In addition to the above installation instructions, install `stylelint-config-prettier`:

    ```sh
    npm install --save-dev stylelint-config-prettier
    ```

2.  Then replace the plugins and rules declarations in your `.stylelintrc` that you added in the prior section with:

    ```json
    {
      "extends": ["stylelint-prettier/recommended"]
    }
    ```

This does three things:

1.  Enables the `stylelint-plugin-prettier` plugin.
2.  Enables the `prettier/prettier` rule.
3.  Extends the `stylelint-config-prettier` configuration.

You can then set Prettier's own options inside a `.prettierrc` file.

https://github.com/prettier/stylelint-prettier

> "extends": ["stylelint-prettier/recommended"]

上記の記述で、pluginsとrulesに記述してあった内容が継承されるため。